### PR TITLE
Fixing long form regex to handle slack api giphy urls

### DIFF
--- a/src/components/dialog/messages/Text.react.js
+++ b/src/components/dialog/messages/Text.react.js
@@ -21,7 +21,7 @@ function processText(text) {
   }
 
   // giphy
-  var giphyRegex = /giphy.com\/gifs\/([^\/]*)/ // long form urls are fine to convert
+  var giphyRegex = /giphy.com\/gifs\/(?:[^-]*-)?([^\/]*)/ // long form urls are fine to convert
 
   if (/gph.is\/(.*)/.exec(text)) { return "I am a dumb idiot for using the giphy short url"; }
 


### PR DESCRIPTION
some urls have some of the gif name inserted before the id
